### PR TITLE
_find_width_index and _handle_long_word change

### DIFF
--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -1118,17 +1118,30 @@ class WideCharacterTestCase(BaseTestCase):
                            text_len=self.text_len)
 
 
-class ZeroWidthTestCase(BaseTestCase):
+class CustomWidthTestCase(BaseTestCase):
     def text_len(self, text):
+        lengths = {
+            'A': 4,
+            'B': 2,
+            'Q': 0,
+        }
+
         return sum(
-            0 if c == 'Q' else 1
+            lengths[c] if c in lengths else 1
             for c in text
         )
 
     def test_zero_width_text_len(self):
-
         text = "0QQ1234QQ56789"
         self.check_wrap(text, 6, ["0QQ1234QQ5", "6789"], text_len=self.text_len)
+
+    def test_char_longer_than_width(self):
+        text = "AA0123"
+        self.check_wrap(text, 3, ["A", "A", "012", "3"], text_len=self.text_len)
+
+    def test_next_char_overflow(self):
+        text = "BB0123"
+        self.check_wrap(text, 3, ["B", "B0", "123"], text_len=self.text_len)
 
 
 if __name__ == '__main__':

--- a/Lib/test/test_textwrap.py
+++ b/Lib/test/test_textwrap.py
@@ -1118,5 +1118,18 @@ class WideCharacterTestCase(BaseTestCase):
                            text_len=self.text_len)
 
 
+class ZeroWidthTestCase(BaseTestCase):
+    def text_len(self, text):
+        return sum(
+            0 if c == 'Q' else 1
+            for c in text
+        )
+
+    def test_zero_width_text_len(self):
+
+        text = "0QQ1234QQ56789"
+        self.check_wrap(text, 6, ["0QQ1234QQ5", "6789"], text_len=self.text_len)
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -200,21 +200,23 @@ class TextWrapper:
                 i += 1
 
     def _find_width_index(self, text, width):
-        """_find_width_index(text : string, width: int)
+        """_find_length_index(text : string, width : int)
 
-        Find at which index the text has the required width.
+        Find at which index the text has the required width, since when using a
+        different text_len, this index will not be equal to the required width.
         """
-        # In most cases text_len will just use the number of characters, so this heuristic prevents calculating width
-        # for each character
+        # When using default len as self.text_len, the required index and width
+        # will be equal, this prevents calculation time.
         if self.text_len(text[:width]) == width:
-            # For character widths greater than one, width can be more than the number of characters
+            # For character widths greater than one, width can be more than the
+            # number of characters
             return min(width, len(text))
         cur_text = ''
         for i, c in enumerate(text):
             cur_text += c
             cur_width = self.text_len(cur_text)
-            if cur_width >= width:
-                return i+1
+            if cur_width > width:
+                return max(i, 1)
 
     def _handle_long_word(self, reversed_chunks, cur_line, cur_len, width):
         """_handle_long_word(chunks : [string],

--- a/Lib/textwrap.py
+++ b/Lib/textwrap.py
@@ -199,6 +199,23 @@ class TextWrapper:
             else:
                 i += 1
 
+    def _find_width_index(self, text, width):
+        """_find_width_index(text : string, width: int)
+
+        Find at which index the text has the required width.
+        """
+        # In most cases text_len will just use the number of characters, so this heuristic prevents calculating width
+        # for each character
+        if self.text_len(text[:width]) == width:
+            # For character widths greater than one, width can be more than the number of characters
+            return min(width, len(text))
+        cur_text = ''
+        for i, c in enumerate(text):
+            cur_text += c
+            cur_width = self.text_len(cur_text)
+            if cur_width >= width:
+                return i+1
+
     def _handle_long_word(self, reversed_chunks, cur_line, cur_len, width):
         """_handle_long_word(chunks : [string],
                              cur_line : [string],
@@ -217,12 +234,12 @@ class TextWrapper:
         # If we're allowed to break long words, then do so: put as much
         # of the next chunk onto the current line as will fit.
         if self.break_long_words:
-            end = space_left
             chunk = reversed_chunks[-1]
+            end = self._find_width_index(chunk, space_left)
             if self.break_on_hyphens and self.text_len(chunk) > space_left:
                 # break after last hyphen, but only if there are
                 # non-hyphens before it
-                hyphen = chunk.rfind('-', 0, space_left)
+                hyphen = chunk.rfind('-', 0, end)
                 if hyphen > 0 and any(c != '-' for c in chunk[:hyphen]):
                     end = hyphen + 1
             cur_line.append(chunk[:end])


### PR DESCRIPTION
(the previous PR was made with the incorrect account, apologies)

# _find_width_index and _handle_long_word change

```
bpo-12499: Fix for zero-width characters in custom text_len function for TextWrapper class
```

See python/cpython#28136 ([specifically this comment](https://github.com/python/cpython/pull/28136#issuecomment-964288046))